### PR TITLE
fix selectWhere on Civi 5.28

### DIFF
--- a/activitytypeacl.php
+++ b/activitytypeacl.php
@@ -431,7 +431,7 @@ function activitytypeacl_civicrm_selectWhereClause($entity, &$clauses) {
   if ($entity == "Activity") {
     $constituent = CRM_Core_Session::singleton()->get('isConstituent');
     if (!$constituent) {
-      $clauses['activity_type_id'] = array(CRM_ActivityTypeACL_BAO_ACL::getAdditionalActivityClause($where, "report"));
+      $clauses['activity_type_id'] = CRM_ActivityTypeACL_BAO_ACL::getAdditionalActivityClause($where, "report");
     }
   }
 }


### PR DESCRIPTION
When this extension is enabled, any activity search (or advanced search based in part on activities) fails with a "DB Syntax Error".  I posted a backtrace below.

It seems we're passing an array where a string is needed - I don't know why or when this changed.

I assume you have at least one client using this extension, so it's easy to replicate the bug and test the solution.

Jon


```
Aug 19 13:23:42  [error] $Fatal Error Details = Array
(
    [callback] => Array
        (
            [0] => CRM_Core_Error
            [1] => handle
        )

    [code] => -2 
    [message] => DB Error: syntax error
    [mode] => 16 
    [debug_info] => SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name
       FROM civicrm_contact contact_a   LEFT JOIN civicrm_activity_contact
                      ON ( civicrm_activity_contact.contact_id = contact_a.id )  LEFT JOIN civicrm_activity
                      ON ( civicrm_activity.id = civicrm_activity_contact.activity_id
                      AND civicrm_activity.is_deleted = 0 AND civicrm_activity.is_current_revision = 1 ) INNER JOIN civicrm_contact
                      ON ( civicrm_activity_contact.contact_id = civicrm_contact.id and civicrm_contact.is_deleted != 1 )
LEFT JOIN civicrm_value_grievance_con_18 ON civicrm_value_grievance_con_18.entity_id = `civicrm_activity`.id 
      WHERE  ( civicrm_activity.status_id IN ("1", "2") AND  civicrm_activity_contact.record_type_id = 3 AND civicrm_activity.is_test = 0 AND civicrm_value_grievance_con_18.other_party_141 = 'palgrave' )  AND  (  ( civicrm_activity.activity_type_id IN (1,2,3,4,5,6,7,8,9,10,11,21,23,29,35,41,49,44,45,46,47,48,50,51,52,53,56,57,58,59,60,61,62,63,65,66,67,68,69,70) )  )  AND (contact_a.is_deleted = 0) AND (civicrm_activity.activity_type_id Array)

      GROUP BY sort_name 
      ORDER BY sort_name asc [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Array)

      GROUP BY sort_name
      ORDER BY sort_name asc' at line 8]
    [type] => DB_Error
    [user_info] => SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name
       FROM civicrm_contact contact_a   LEFT JOIN civicrm_activity_contact
                      ON ( civicrm_activity_contact.contact_id = contact_a.id )  LEFT JOIN civicrm_activity
                      ON ( civicrm_activity.id = civicrm_activity_contact.activity_id
                      AND civicrm_activity.is_deleted = 0 AND civicrm_activity.is_current_revision = 1 ) INNER JOIN civicrm_contact
                      ON ( civicrm_activity_contact.contact_id = civicrm_contact.id and civicrm_contact.is_deleted != 1 )
LEFT JOIN civicrm_value_grievance_con_18 ON civicrm_value_grievance_con_18.entity_id = `civicrm_activity`.id
      WHERE  ( civicrm_activity.status_id IN ("1", "2") AND  civicrm_activity_contact.record_type_id = 3 AND civicrm_activity.is_test = 0 AND civicrm_value_grievance_con_18.other_party_141 = 'palgrave' )  AND  (  ( civicrm_activity.activity_type_id IN (1,2,3,4,5,6,7,8,9,10,11,21,23,29,35,41,49,44,45,46,47,48,50,51,52,53,56,57,58,59,60,61,62,63,65,66,67,68,69,70) )  )  AND (contact_a.is_deleted = 0) AND (civicrm_activity.activity_type_id Array)

      GROUP BY sort_name
      ORDER BY sort_name asc [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Array)

      GROUP BY sort_name
      ORDER BY sort_name asc' at line 8]
    [to_string] => [db_error: message="DB Error: syntax error" code=-2 mode=callback callback=CRM_Core_Error::handle prefix="" info="SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name
       FROM civicrm_contact contact_a   LEFT JOIN civicrm_activity_contact
                      ON ( civicrm_activity_contact.contact_id = contact_a.id )  LEFT JOIN civicrm_activity
                      ON ( civicrm_activity.id = civicrm_activity_contact.activity_id
                      AND civicrm_activity.is_deleted = 0 AND civicrm_activity.is_current_revision = 1 ) INNER JOIN civicrm_contact
                      ON ( civicrm_activity_contact.contact_id = civicrm_contact.id and civicrm_contact.is_deleted != 1 )
LEFT JOIN civicrm_value_grievance_con_18 ON civicrm_value_grievance_con_18.entity_id = `civicrm_activity`.id
      WHERE  ( civicrm_activity.status_id IN ("1", "2") AND  civicrm_activity_contact.record_type_id = 3 AND civicrm_activity.is_test = 0 AND civicrm_value_grievance_con_18.other_party_141 = 'palgrave' )  AND  (  ( civicrm_activity.activity_type_id IN (1,2,3,4,5,6,7,8,9,10,11,21,23,29,35,41,49,44,45,46,47,48,50,51,52,53,56,57,58,59,60,61,62,63,65,66,67,68,69,70) )  )  AND (contact_a.is_deleted = 0) AND (civicrm_activity.activity_type_id Array)

      GROUP BY sort_name
      ORDER BY sort_name asc [nativecode=1064 ** You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Array)

      GROUP BY sort_name
      ORDER BY sort_name asc' at line 8]"]
)


Aug 19 13:23:42  [debug] $backTrace = #0 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Error.php(205): CRM_Core_Error::backtrace("backTrace", TRUE)
#1 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/PEAR.php(921): CRM_Core_Error::handle(Object(DB_Error))
#2 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/DB.php(997): PEAR_Error->__construct("DB Error: syntax error", -2, 16, (Array:2), "SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...")
#3 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/PEAR.php(575): DB_Error->__construct(-2, 16, (Array:2), "SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...")
#4 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/PEAR.php(223): PEAR->_raiseError(Object(DB_mysqli), NULL, -2, 16, (Array:2), "SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...", "DB_Error", TRUE)
#5 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/DB/common.php(1925): PEAR->__call("raiseError", (Array:7))
#6 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/DB/mysqli.php(936): DB_common->raiseError(-2, NULL, NULL, "SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...", "1064 ** You have an error in your SQL syntax; check the manual that correspon...")
#7 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/DB/mysqli.php(406): DB_mysqli->mysqliRaiseError()
#8 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/DB/common.php(1231): DB_mysqli->simpleQuery("SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...")
#9 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/DB/DataObject.php(2696): DB_common->query("SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...")
#10 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/DB/DataObject.php(1829): DB_DataObject->_query("SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...")
#11 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php(439): DB_DataObject->query("SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...")
#12 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/DAO.php(1528): CRM_Core_DAO->query("SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...", TRUE)
#13 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Contact/BAO/Query.php(4976): CRM_Core_DAO::executeQuery("SELECT DISTINCT LEFT(contact_a.sort_name, 1) as sort_name\n       FROM civicr...")
#14 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Contact/Selector.php(1196): CRM_Contact_BAO_Query->alphabetQuery()
#15 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Utils/PagerAToZ.php(92): CRM_Contact_Selector->alphabetQuery()
#16 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Utils/PagerAToZ.php(120): CRM_Utils_PagerAToZ::getDynamicCharacters(Object(CRM_Contact_Selector), FALSE)
#17 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Utils/PagerAToZ.php(36): CRM_Utils_PagerAToZ::createLinks(Object(CRM_Contact_Selector), NULL, FALSE)
#18 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Contact/Form/Search.php(848): CRM_Utils_PagerAToZ::getAToZBar(Object(CRM_Contact_Selector), NULL)
#19 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Contact/Form/Search/Advanced.php(304): CRM_Contact_Form_Search->postProcess()
#20 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Form.php(504): CRM_Contact_Form_Search_Advanced->postProcess()
#21 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/QuickForm/Action/Refresh.php(59): CRM_Core_Form->mainProcess()
#22 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/HTML/QuickForm/Controller.php(203): CRM_Core_QuickForm_Action_Refresh->perform(Object(CRM_Contact_Form_Search_Advanced), "refresh")
#23 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/packages/HTML/QuickForm/Page.php(103): HTML_QuickForm_Controller->handle(Object(CRM_Contact_Form_Search_Advanced), "refresh")
#24 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Controller.php(347): HTML_QuickForm_Page->handle("refresh")
#25 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(312): CRM_Core_Controller->run((Array:4), (Array:0))
#26 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(68): CRM_Core_Invoke::runItem((Array:13))
#27 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm/CRM/Core/Invoke.php(36): CRM_Core_Invoke::_invoke((Array:4))
#28 /var/www/mysite.org/htdocs/wp-content/plugins/civicrm/civicrm.php(1601): CRM_Core_Invoke::invoke((Array:4))
#29 /var/www/mysite.org/htdocs/wp-includes/class-wp-hook.php(287): CiviCRM_For_WordPress->invoke("")
#30 /var/www/mysite.org/htdocs/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters("", (Array:1))
#31 /var/www/mysite.org/htdocs/wp-includes/plugin.php(478): WP_Hook->do_action((Array:1))
#32 /var/www/mysite.org/htdocs/wp-admin/admin.php(259): do_action("toplevel_page_CiviCRM")
#33 {main}
```