### PR TITLE
Fix Regression from 5.28.0 which causes Activity Search to break

### DIFF
--- a/activitytypeacl.php
+++ b/activitytypeacl.php
@@ -431,7 +431,13 @@ function activitytypeacl_civicrm_selectWhereClause($entity, &$clauses) {
   if ($entity == "Activity") {
     $constituent = CRM_Core_Session::singleton()->get('isConstituent');
     if (!$constituent) {
-      $clauses['activity_type_id'] = array(CRM_ActivityTypeACL_BAO_ACL::getAdditionalActivityClause($where, "report"));
+      $whereClause = CRM_ActivityTypeACL_BAO_ACL::getAdditionalActivityClause($where, "report");
+      if (!empty($clauses['activity_type_id'])) {
+        $clauses['activity_type_id'] .= $whereClause;
+      }
+      else {
+        $clauses['activity_type_id'] = $whereClause;
+      }
     }
   }
 }


### PR DESCRIPTION
This is a regression following https://github.com/civicrm/civicrm-core/commit/d1d108ee227039e6eee69dd037c626cd9b301c20 which added its own select where clause handling and extended that onto Search

@kcristiano I believe this will fix the problem for the Libertarians that you reported