### PR TITLE
add defaultReturnProperties to not break in 5.47+

### DIFF
--- a/CRM/ActivityTypeACL/BAO/Query.php
+++ b/CRM/ActivityTypeACL/BAO/Query.php
@@ -83,4 +83,7 @@ class CRM_ActivityTypeACL_BAO_Query {
   public static function alterSearchBuilderOptions(&$apiEntities, &$fieldOptions) {
   }
 
+  public static function defaultReturnProperties($mode) {
+  }
+
 }


### PR DESCRIPTION
https://github.com/civicrm/civicrm-core/pull/22064 changes the interface for query objects, adding a new method.  If you go to any page that calls this hook (e.g. any search page, dedupe, etc.) you'll get a WSOD without this patch.